### PR TITLE
[tock] Update CW310 FPGA loader command

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -39,21 +39,6 @@ the Python dependencies are installed.
 python3 pip install -r python-requirements.txt
 ```
 
-Next connect to the board's serial with a second terminal:
-
-```shell
-screen /dev/ttyACM1 115200,cs8,-ixon,-ixoff
-```
-
-Then you need to flash the bitstream with:
-
-
-```shell
-./util/fpga/cw310_loader.py --bitstream lowrisc_systems_chip_earlgrey_cw310_0.1.bit --set-pll-defaults
-```
-
-After which you should see some output in the serial window.
-
 Then in the Tock board directoty export the `OPENTITAN_TREE` enviroment
 variable to point to the OpenTitan tree.
 
@@ -61,7 +46,44 @@ variable to point to the OpenTitan tree.
 export OPENTITAN_TREE=/home/opentitan/
 ```
 
-then you can run `make flash` or `make test-hardware` to use the board.
+Provide following configuration in a file "$XDG_CONFIG_HOME/opentitantool/config".
+(please replace <...> with you opentitan source directory path)
+
+```
+--interface=cw310
+--conf=<OPENTITAN_TREE>/sw/host/opentitanlib/src/app/config/opentitan_cw310.json
+```
+
+For user convenience, it is useful to add opentitantool to PATH.
+
+```shell
+export PATH="$OPENTITAN_TREE/bazel-bin/sw/host/opentitantool:$PATH"
+```
+
+Download latest prebuild bitstream:
+
+```shell
+mkdir -p /tmp/bitstream-latest
+cd /tmp/bitstream-latest
+curl https://storage.googleapis.com/opentitan-bitstreams/master/bitstream-latest.tar.gz -o bitstream-latest.tar.gz
+tar -xvf bitstream-latest.tar.gz
+```
+
+Next connect to the board's serial with a second terminal:
+
+```shell
+screen /dev/ttyACM1 115200,cs8,-ixon,-ixoff
+```
+
+Then you need to flash the bitstream with command:
+
+```shell
+opentitantool fpga load-bitstream /tmp/bitstream-latest/lowrisc_systems_chip_earlgrey_cw310_0.1.bit
+opentitantool fpga set-pll
+```
+
+After which you should see some output in the serial window.
+Then you can run `make flash` or `make test-hardware` to use the board.
 
 Verilator
 ---------

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -6,7 +6,7 @@ PLATFORM=earlgrey-cw310
 FLASHID=--dev-id="0403:6010"
 RISC_PREFIX ?= riscv64-elf
 QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
-
+OTT=bazel-bin/sw/host/opentitantool/opentitantool
 
 include ../../Makefile.common
 
@@ -40,12 +40,12 @@ qemu-app-gdb : $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(QEMU) -s -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(OPENTITAN_TREE)$(OTT) bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
-	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
+	$(OPENTITAN_TREE)$(OTT) bootstrap $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
 verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(call check_defined, OPENTITAN_TREE)

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 BUILD_DIR="verilator_build/"
+OTT="bazel-bin/sw/host/opentitantool/opentitantool"
 
 if [[ "${VERILATOR}" == "yes" ]]; then
 		if [ -d "$BUILD_DIR" ]; then
@@ -26,7 +27,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
 	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary
-	${OPENTITAN_TREE}/util/fpga/cw310_loader.py --firmware binary
+	${OPENTITAN_TREE}${OTT} bootstrap binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"
 fi


### PR DESCRIPTION
This commit replace old (obsolete) cw310_loader.py with opentitantool.

Signed-off-by: Michał Mazurek <maz@semihalf.org>

### Pull Request Overview

This PR replace old fpga python loader script with opentitantool.

### Testing Strategy

This pull request was tested by...

```
make flash
```

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated READMY.md with description how to use opentitantool

### Formatting

- [ ] Ran `make prepush`.
