### PR TITLE
board/opentitan: Add manifest version to linker script

### DIFF
--- a/boards/opentitan/earlgrey-cw310/layout.ld
+++ b/boards/opentitan/earlgrey-cw310/layout.ld
@@ -27,6 +27,7 @@ SECTIONS {
         . += 384; /* rsa_modulus */
         . += 4;   /* address_translation */
         . += 4;   /* identifier */
+        . += 4;   /* manifest_version */
         . += 4;   /* signed_region_end */
         . += 4;   /* length */
         . += 4;   /* version_major */
@@ -42,9 +43,9 @@ SECTIONS {
         LONG(_stext - ORIGIN(rom)); /* entry_point */
         /* manifest extension table */
         /* see: sw/device/silicon_creator/lib/base/chip.h */
-        /* CHIP_MANIFEST_EXT_TABLE_COUNT = 8 */
+        /* CHIP_MANIFEST_EXT_TABLE_COUNT = 16 */
         /* sizeof(manifest_ext_table_entry) = 8 */
-        . += 64; /* manifest_ext_table */
+        . += 128; /* manifest_ext_table */
     } > rom
 
     .vectors : ALIGN (256) {

--- a/boards/opentitan/earlgrey-cw310/test_layout.ld
+++ b/boards/opentitan/earlgrey-cw310/test_layout.ld
@@ -35,6 +35,7 @@ SECTIONS {
         . += 384; /* modulus */
         . += 4;   /* address_translation */
         . += 4;   /* identifier */
+        . += 4;   /* manifest_version */
         . += 4;   /* length */
         . += 4;   /* version_major */
         . += 4;   /* version_minor */
@@ -45,8 +46,11 @@ SECTIONS {
         . += 4;   /* code_start */
         . += 4;   /* code_end */
         LONG(_stext - ORIGIN(rom)); /* . = . + 4; entry_point */
-        . += 176; /* padding */
-        /* size = 8960 bytes */
+        /* manifest extension table */
+        /* see: sw/device/silicon_creator/lib/base/chip.h */
+        /* CHIP_MANIFEST_EXT_TABLE_COUNT = 16 */
+        /* sizeof(manifest_ext_table_entry) = 8 */
+        . += 128; /* manifest_ext_table */
     } > rom
 
     .vectors : ALIGN (256) {


### PR DESCRIPTION
Update linker script to support changes in OpenTitan ROM.


Following commits increase manifest extension table form to 16, and add 4 bytes filed manifest_version.

OpenTitan ROM changes [PR#18839](https://github.com/lowRISC/opentitan/pull/18839)

SHA: e2d7f0c3749fd36d10d5e694c7899ddea23309fb
SHA: 30f44025dfb4bc2bd328a99a0a810c3189fb2544a

Test:
Invocation of following command in order to check if board boot correctly
```
cd $TOCK_DIR/boards/opentitan/earlgrey-cw310 
make flash
```
Output captured from UART:
```
I00000 test_rom.c:160] kChipInfo: scm_revision=eb4b2214
I00001 test_rom.c:186] TestROM:632e99df
I00002 test_rom.c:243] Test ROM complete, jumping to flash (addr: 20000410)!
Unable to find otbn-rsa, disabling RSA support
OpenTitan initialisation complete. Entering main loop
```
