### PR TITLE
Update Earlgrey M-2.5.2-RC0

### DIFF
--- a/chips/earlgrey/src/registers/alert_handler_regs.rs
+++ b/chips/earlgrey/src/registers/alert_handler_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/ast_regs.rs
+++ b/chips/earlgrey/src/registers/ast_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/ast/data/ast.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/clkmgr_regs.rs
+++ b/chips/earlgrey/src/registers/clkmgr_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/flash_ctrl_regs.rs
+++ b/chips/earlgrey/src/registers/flash_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
 use kernel::utilities::registers::ReadOnly;

--- a/chips/earlgrey/src/registers/pinmux_regs.rs
+++ b/chips/earlgrey/src/registers/pinmux_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/pwrmgr_regs.rs
+++ b/chips/earlgrey/src/registers/pwrmgr_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/rstmgr_regs.rs
+++ b/chips/earlgrey/src/registers/rstmgr_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/rv_plic_regs.rs
+++ b/chips/earlgrey/src/registers/rv_plic_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/registers/sensor_ctrl_regs.rs
+++ b/chips/earlgrey/src/registers/sensor_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/earlgrey/src/top_earlgrey.rs
+++ b/chips/earlgrey/src/top_earlgrey.rs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Built for earlgrey_silver_release_v5-11437-gb228e6a8c
-// https://github.com/lowRISC/opentitan/tree/b228e6a8c6f28861bcfcdb2252e9b60407245d06
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-06-05T16:22:07.882281
+// Build date: 2023-07-20T09:36:12.725946
 
 // This file was generated automatically.
 // Please do not modify content of this file directly.

--- a/chips/lowrisc/src/registers/adc_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/adc_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/adc_ctrl/data/adc_ctrl.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/aes_regs.rs
+++ b/chips/lowrisc/src/registers/aes_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/aes/data/aes.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/aon_timer_regs.rs
+++ b/chips/lowrisc/src/registers/aon_timer_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/aon_timer/data/aon_timer.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/clkmgr_regs.rs
+++ b/chips/lowrisc/src/registers/clkmgr_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/clkmgr/data/clkmgr.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/csrng_regs.rs
+++ b/chips/lowrisc/src/registers/csrng_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/csrng/data/csrng.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/edn_regs.rs
+++ b/chips/lowrisc/src/registers/edn_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/edn/data/edn.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/entropy_src_regs.rs
+++ b/chips/lowrisc/src/registers/entropy_src_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/entropy_src/data/entropy_src.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/flash_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/flash_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/flash_ctrl/data/flash_ctrl.hjson
 use kernel::utilities::registers::ReadOnly;

--- a/chips/lowrisc/src/registers/gpio_regs.rs
+++ b/chips/lowrisc/src/registers/gpio_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/gpio/data/gpio.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/hmac_regs.rs
+++ b/chips/lowrisc/src/registers/hmac_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/hmac/data/hmac.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/i2c_regs.rs
+++ b/chips/lowrisc/src/registers/i2c_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/i2c/data/i2c.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/keymgr_regs.rs
+++ b/chips/lowrisc/src/registers/keymgr_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/keymgr/data/keymgr.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/kmac_regs.rs
+++ b/chips/lowrisc/src/registers/kmac_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/kmac/data/kmac.hjson
 use kernel::utilities::registers::ReadOnly;

--- a/chips/lowrisc/src/registers/lc_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/lc_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/lc_ctrl/data/lc_ctrl.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/otbn_regs.rs
+++ b/chips/lowrisc/src/registers/otbn_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/otbn/data/otbn.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/otp_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/otp_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/otp_ctrl/data/otp_ctrl.hjson
 use kernel::utilities::registers::ReadOnly;
@@ -171,6 +171,10 @@ pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_ALERT_THRESHOLD_SIZE: u32 = 4;
 pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST_OFFSET: usize = 348;
 /// Size of CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST
 pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_RNG_HEALTH_CONFIG_DIGEST_SIZE: u32 = 4;
+/// Offset of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_OFFSET: usize = 352;
+/// Size of CREATOR_SW_CFG_SRAM_KEY_RENEW_EN
+pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_SRAM_KEY_RENEW_EN_SIZE: u32 = 4;
 /// Offset of CREATOR_SW_CFG_DIGEST
 pub const OTP_CTRL_PARAM_CREATOR_SW_CFG_DIGEST_OFFSET: usize = 856;
 /// Size of CREATOR_SW_CFG_DIGEST
@@ -243,6 +247,10 @@ pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_KEYMGR_ROM_EXT_MEAS_EN_SIZE: u32 = 4;
 pub const OTP_CTRL_PARAM_OWNER_SW_CFG_MANUF_STATE_OFFSET: usize = 1384;
 /// Size of OWNER_SW_CFG_MANUF_STATE
 pub const OTP_CTRL_PARAM_OWNER_SW_CFG_MANUF_STATE_SIZE: u32 = 4;
+/// Offset of OWNER_SW_CFG_ROM_RSTMGR_INFO_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_RSTMGR_INFO_EN_OFFSET: usize = 1388;
+/// Size of OWNER_SW_CFG_ROM_RSTMGR_INFO_EN
+pub const OTP_CTRL_PARAM_OWNER_SW_CFG_ROM_RSTMGR_INFO_EN_SIZE: u32 = 4;
 /// Offset of OWNER_SW_CFG_DIGEST
 pub const OTP_CTRL_PARAM_OWNER_SW_CFG_DIGEST_OFFSET: usize = 1656;
 /// Size of OWNER_SW_CFG_DIGEST

--- a/chips/lowrisc/src/registers/pattgen_regs.rs
+++ b/chips/lowrisc/src/registers/pattgen_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/pattgen/data/pattgen.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/pinmux_regs.rs
+++ b/chips/lowrisc/src/registers/pinmux_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/pinmux/data/pinmux.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/pwm_regs.rs
+++ b/chips/lowrisc/src/registers/pwm_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/pwm/data/pwm.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/rom_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/rom_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/rom_ctrl/data/rom_ctrl.hjson
 use kernel::utilities::registers::ReadOnly;

--- a/chips/lowrisc/src/registers/rv_core_ibex_regs.rs
+++ b/chips/lowrisc/src/registers/rv_core_ibex_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/rv_timer_regs.rs
+++ b/chips/lowrisc/src/registers/rv_timer_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/rv_timer/data/rv_timer.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/spi_device_regs.rs
+++ b/chips/lowrisc/src/registers/spi_device_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/spi_device/data/spi_device.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/spi_host_regs.rs
+++ b/chips/lowrisc/src/registers/spi_host_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/spi_host/data/spi_host.hjson
 use kernel::utilities::registers::ReadOnly;

--- a/chips/lowrisc/src/registers/sram_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/sram_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/sram_ctrl/data/sram_ctrl.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/sysrst_ctrl_regs.rs
+++ b/chips/lowrisc/src/registers/sysrst_ctrl_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/uart_regs.rs
+++ b/chips/lowrisc/src/registers/uart_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/uart/data/uart.hjson
 use kernel::utilities::registers::ReadWrite;

--- a/chips/lowrisc/src/registers/usbdev_regs.rs
+++ b/chips/lowrisc/src/registers/usbdev_regs.rs
@@ -3,10 +3,10 @@
 //   Apache License, Version 2.0 (LICENSE-APACHE <http://www.apache.org/licenses/LICENSE-2.0>)
 //   MIT License (LICENSE-MIT <http://opensource.org/licenses/MIT>)
 
-// Built for earlgrey_silver_release_v5-11270-gcd74b4221
-// https://github.com/lowRISC/opentitan/tree/cd74b42214fb37ba6b2d5bd4fa13ff0273f77e4e
+// Built for Earlgrey-M2.5.1-RC1-389-g21ce4e9761
+// https://github.com/lowRISC/opentitan/tree/21ce4e9761abdf5c919b46e5ae64a5a8e24992f7
 // Tree status: clean
-// Build date: 2023-05-26T10:18:40
+// Build date: 2023-07-20T09:13:24
 
 // Original reference file: hw/ip/usbdev/data/usbdev.hjson
 use kernel::utilities::registers::ReadWrite;


### PR DESCRIPTION
This is formal PR that update the register and chip definition to a release
candidate used in current OpenTitan engineering sample.

Release tag: Earlgrey-M2.5.2-RC0

To test this PR please execute following commands:
`cd  boards/opentitan/earlgrey-cw310 && make flash`